### PR TITLE
Remove Itinerary#== and inherit ValueObject

### DIFF
--- a/domain/cargo/itinerary.rb
+++ b/domain/cargo/itinerary.rb
@@ -1,7 +1,7 @@
 require 'ice_nine'
 require 'hamster'
 
-class Itinerary
+class Itinerary < ValueObject
   attr_reader :legs
 
   # TODO Handle empty values for attributes by returning UNKNOWN location
@@ -43,18 +43,5 @@ class Itinerary
       return legs.last.unload_location == handling_event.location
     end
     false
-  end
-
-  def ==(other)
-    # TODO Ugly Ruby - must be a better way to compare two arrays for equality of values
-    leg_index = 0
-    equal = true
-    self.legs.each do |leg|
-      unless leg == other.legs[leg_index]
-        equal = false
-      end
-      leg_index = leg_index + 1
-    end
-    equal
   end
 end

--- a/spec/lib/value_object_spec.rb
+++ b/spec/lib/value_object_spec.rb
@@ -79,6 +79,58 @@ describe ValueObject do
 
       (obj1 == obj2).should be_false
     end
+    
+    it "returns true if its attribute containing array of value objects are equal" do
+      child_klass  = klass
+      
+      parent_klass = Class.new(ValueObject) do
+                       attr_reader :children
+                       
+                       def initialize(children)
+                         @children = children
+                       end
+                     end
+
+      value1 = random_string
+      value2 = random_string
+
+      child1a = child_klass.new(value1, value2)
+      child1b = child1a.dup
+      
+      child2a = child_klass.new(value2, value1)
+      child2b = child2a.dup
+
+      parent1 = parent_klass.new([child1a, child2a])
+      parent2 = parent_klass.new([child1b, child2b])
+      
+      (parent1 == parent2).should be_true
+    end
+
+    it "returns false if its attribute containing array of value objects are not equal" do
+      child_klass  = klass
+      
+      parent_klass = Class.new(ValueObject) do
+                       attr_reader :children
+                       
+                       def initialize(children)
+                         @children = children
+                       end
+                     end
+
+      value1 = random_string
+      value2 = random_string
+
+      child1a = child_klass.new(value1, value2)
+      child1b = child1a.dup
+      
+      child2a = child_klass.new(value2, value1)
+      child2b = child2a.dup
+
+      parent1 = parent_klass.new([child1a, child2a])
+      parent2 = parent_klass.new([child2b, child2b])
+      
+      (parent1 == parent2).should be_false
+    end
 
   end # context #==
 


### PR DESCRIPTION
The handcoded #== method is no longer necessary since ValueObject
is capable of comparing attributes that are array of Value Objects as
proven by rev 62ca9c56c7 (also part of this PR).
